### PR TITLE
Restore Pat shell as layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { ReactNode } from "react";
+import { Outlet } from "react-router-dom";
+import HamburgerMenu from "./components/HamburgerMenu";
 
 const avatarGlow = {
   width: 200,
@@ -103,12 +105,15 @@ function ChatInputBar() {
   );
 }
 
-export default function App() {
+interface AppProps { children?: ReactNode }
+
+export default function App({ children }: AppProps) {
   return (
     <div style={{
       minHeight: "100vh", background: "#000", color: "#fff", fontFamily: "sans-serif",
       display: "flex", flexDirection: "column", alignItems: "center", position: "relative"
     }}>
+      <HamburgerMenu />
       <PatAvatar />
       <QuickActions />
       <div style={{
@@ -120,6 +125,7 @@ export default function App() {
         }}>
           HOME CONTENT TEST
         </h1>
+        {children || <Outlet />}
       </div>
       <ChatInputBar />
     </div>

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function HamburgerMenu() {
+  return (
+    <button
+      aria-label="Menu"
+      style={{
+        position: 'absolute',
+        top: 16,
+        left: 16,
+        background: 'transparent',
+        color: '#fff',
+        fontSize: 24,
+        border: 'none',
+        cursor: 'pointer'
+      }}
+    >
+      ☰
+    </button>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,8 @@
 export default function Dashboard() {
   return (
     <div className="p-8 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Dashboard</h1>
-      <p className="text-gray-600">
-        This is a placeholder.  Data widgets will appear here once the agent
-        backend is wired in.
-      </p>
+      <h1 className="text-2xl font-semibold mb-4">Dashboard Page</h1>
+      <p className="text-gray-600">This is the dashboard placeholder content.</p>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,33 +1,8 @@
-import PatAvatar from "../components/PatAvatar";
-import QuickSuggestionChips from "../components/QuickSuggestionChips";
-import ChatWindow from "../components/ChatWindow";
-import { useState } from "react";
-
 export default function Home() {
-  const [hasChatted, setHasChatted] = useState(false);
-
-  const quick = [
-    { label: "Tell me what you ate",       onClick: () => send("Tell me what you ate") },
-    { label: "Tell me about your workout", onClick: () => send("Tell me about my workout") },
-    { label: "Ask me anything",            onClick: () => send("Ask me anything") },
-    { label: "Make me better",             onClick: () => send("Make me better") }
-  ];
-
-  function send(msg: string) {
-    setHasChatted(true);
-    /* TODO: wire into existing send-message logic */
-    console.log("[send]", msg);
-  }
-
   return (
-    <div className="min-h-screen flex flex-col bg-white text-gray-900">
-      <div className="flex-1 flex flex-col items-center pt-12 px-4">
-        <PatAvatar size={128} />
-        <QuickSuggestionChips replies={quick} hide={hasChatted} />
-        <div className="w-full max-w-3xl flex-1 mt-8">
-          <ChatWindow onSend={send} className="h-full" />
-        </div>
-      </div>
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold mb-4">Home Page</h1>
+      <p className="text-gray-600">This is the home page placeholder content.</p>
     </div>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
+import App from './App';
 import { AdminPanel } from './components/Admin/AdminPanel';
 import { FeedbackButton } from './components/Feedback';
 import Home from './pages/Home';
@@ -31,9 +32,9 @@ export const router = createBrowserRouter([
     path: '/',
     element: (
       <ProtectedRoute>
-        <MainLayout>
+        <App>
           <Home />
-        </MainLayout>
+        </App>
       </ProtectedRoute>
     ),
   },
@@ -71,10 +72,9 @@ export const router = createBrowserRouter([
     path: '/dashboard',
     element: (
       <ProtectedRoute>
-        <MainLayout>
+        <App>
           <Dashboard />
-          <FeedbackFab />
-        </MainLayout>
+        </App>
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## Summary
- create simple `HamburgerMenu` component
- add menu and outlet support in `App` shell
- stub pages for Home and Dashboard
- use the shell for '/' and '/dashboard' routes

## Testing
- `npm run dev` *(fails: process stops but server built successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684204c844988332a209fd8e2f916528